### PR TITLE
embed calendar from nextcloud

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,20 +13,15 @@
 <p>4534 ½ University Way NE</p>
 <br>
 
-<h2>calendar</h2>
-<dl>
-<dt>queer open hack night : weekly thursdays 4:30pm-8:00pm</dt>
-<dt>bioinformatics night : friday, august 23rd 5-8pm</dt>
-<!-- <dt>Movie &amp; social time : weekly sundays 2pm onwards</dt> -->
-<dt>monthly member meeting : second thursday monthly 7:30pm</dt>
-<dt>amateur radio license exam : thursday, september 19th 6pm (<a target="_blank" href="https://ham.study/sessions/66c7dbb49ef4e81427a7b06c/1">register</a>, <a target="_blank" href="https://www.arrl.org/exam_sessions/seattle-wa-98105-4511">contact</a>)</dt>
-</dl>
-
 <h2>contact</h2>
 <!-- the display version of this is homoglyph-substituted. all of these
      currently have email redirects but if spam starts happening we can change
      things up -->
 <a href="mailto:hello-25@devhack.net">һëⅼⅼо@devhack.net</a>
+
+
+<h2>calendar</h2>
+<iframe width="700" height="900" src="https://nextcloud.devhack.net/apps/calendar/embed/ecGookjEW4NtHNBi"></iframe>
 
 </body>
 </html> 


### PR DESCRIPTION
This will enable easier event creation, and allow old events to stop showing up after a normal amount of time. I will admit, it does not look nearly as sexy, so including screenshots. I'm marking this as a draft because I would like to find a way to make it look better, but I'm not sure if that's everyone's priority vs enabling self-service event publishing.

On desktop, note that I have advanced to next month so there are actual events:

![image](https://github.com/user-attachments/assets/4f47d1e3-9c3f-4f15-b976-4e12a255e35f)


On mobile (iPhone SE 2) after scrolling down but not zooming out or scrolling over:

![24-08-26 15-11-26 5316](https://github.com/user-attachments/assets/71c22211-59af-4eda-ac25-31cbb08ae4d0)
