### PR TITLE
Hide full calendar under a collapsible; show full address on hover 

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <body>
 
 <h1>/dev/hack 
-<span style="display: inline-block; white-space: nowrap">$ <input type="text" autofocus name="_"></input></span>
+<span style="display: inline-block; white-space: nowrap">$ <input type="text" autofocus name="_"></span>
 </h1>
 <p>seattle hackerspace</p>
 <p>4534 ½ University Way NE</p>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 <span style="display: inline-block; white-space: nowrap">$ <input type="text" autofocus name="_"></span>
 </h1>
 <p>seattle hackerspace</p>
-<p>4534 ½ University Way NE</p>
+<p>
+     <span class="address">4534½ University&nbsp;Way&nbsp;NE<span class="address-hide">, Seattle,&nbsp;WA 98105-4511</span>
+     <span class="address-hide">(<a href="https://wiki.devhack.net/Directions">getting here</a>)</span></span>
+</p>
 <details>
      <summary>what's going on at the space?</summary>
      <iframe width="700" height="900" src="https://nextcloud.devhack.net/apps/calendar/embed/ecGookjEW4NtHNBi"></iframe>

--- a/index.html
+++ b/index.html
@@ -11,17 +11,16 @@
 </h1>
 <p>seattle hackerspace</p>
 <p>4534 ½ University Way NE</p>
+<details>
+     <summary>what's going on at the space?</summary>
+     <iframe width="700" height="900" src="https://nextcloud.devhack.net/apps/calendar/embed/ecGookjEW4NtHNBi"></iframe>
+</details>
 <br>
-
 <h2>contact</h2>
 <!-- the display version of this is homoglyph-substituted. all of these
      currently have email redirects but if spam starts happening we can change
      things up -->
 <a href="mailto:hello-25@devhack.net">һëⅼⅼо@devhack.net</a>
-
-
-<h2>calendar</h2>
-<iframe width="700" height="900" src="https://nextcloud.devhack.net/apps/calendar/embed/ecGookjEW4NtHNBi"></iframe>
 
 </body>
 </html> 

--- a/style.css
+++ b/style.css
@@ -32,3 +32,20 @@ dt::before {
 ul {
     list-style-type: '- ';
 }
+
+.address-hide {
+    opacity: 0.5;
+}
+
+@media only screen and (min-width: 768px)  { 
+    /* For desktop, only show the address on hover. For mobile devices let's not
+    make people go through that. */
+    .address-hide {
+        display: none;
+    }
+}
+
+.address:hover .address-hide,
+.address-hide:hover .address-hide {
+    display: inline;
+}


### PR DESCRIPTION
Since NextCloud doesn't really let you customize the iframe calendar color scheme, currently the calendar looks a tad striking on the home page black background. This change makes it so that the calendar is hidden by default under a `<details>`.

Also sneak in a change where you can hover over the address to get the full street address and a link to the "Getting Here" wiki. 

<img width="705" alt="4534½ University Way NE <dropdown> what's going on at the space?
" src="https://github.com/user-attachments/assets/a0e9e7eb-51cf-4733-8eca-2f5770275435">



